### PR TITLE
Fixed LockFactory constructor call in examples

### DIFF
--- a/examples/acquire
+++ b/examples/acquire
@@ -11,9 +11,9 @@ use Predis\Client;
 
 $factory = new LockFactory(
     new RedisDriver(
-        new Client(),
-        new UuidVersion4Generator()
-    )
+        new Client()
+    ),
+    new UuidVersion4Generator()
 );
 
 echo 'Waiting for lock ...' . PHP_EOL;

--- a/examples/extend
+++ b/examples/extend
@@ -11,9 +11,9 @@ use Predis\Client;
 
 $factory = new LockFactory(
     new RedisDriver(
-        new Client(),
-        new UuidVersion4Generator()
-    )
+        new Client()
+    ),
+    new UuidVersion4Generator()
 );
 
 echo 'Waiting for lock ...' . PHP_EOL;


### PR DESCRIPTION
Both the acquire and extend examples attempt to pass two parameters to the
[RedisDriver constructor](https://github.com/IcecaveStudios/chastity/blob/a418a3f501034391c2c5c6dd9af541be2159f3a4/src/Driver/Redis/RedisDriver.php#L19-23), the latter of which is intended for the [LockFactory constructor](https://github.com/IcecaveStudios/chastity/blob/a418a3f501034391c2c5c6dd9af541be2159f3a4/src/LockFactory.php#L19-22).
